### PR TITLE
Add synchronization to ensure that the integration test repository is only created once

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ k8s-openapi = { version = "0.11", default-features = false, features = ["v1_20"]
 kube = "0.56"
 kube-derive = "0.56"
 kube-runtime = "0.56"
+once_cell = "1.8"
 schemars = "0.8"
 serde = "1.0"
 serde_json = "1.0"

--- a/src/test/repository.rs
+++ b/src/test/repository.rs
@@ -45,7 +45,7 @@ pub fn setup_repository(client: &TestKubeClient) {
     // Executing this multiple times can cause issues with K3s, so we ensure
     // that the code is only executed once, regardless of how many test cases
     // try to create the repository
-    if let Ok(_) = REPO_CREATED.set(true) {
+    if REPO_CREATED.set(true).is_ok() {
         client.apply_crd(&Repository::crd());
         client.apply::<Repository>(REPO_SPEC);
     };

--- a/src/test/repository.rs
+++ b/src/test/repository.rs
@@ -3,6 +3,7 @@
 use super::prelude::{KubeClient, TestKubeClient};
 use anyhow::Result;
 use kube_derive::CustomResource;
+use once_cell::sync::OnceCell;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -37,9 +38,17 @@ pub enum RepoType {
     StackableRepo,
 }
 
+static REPO_CREATED: OnceCell<bool> = OnceCell::new();
+
+#[allow(unused_must_use)]
 pub fn setup_repository(client: &TestKubeClient) {
-    client.apply_crd(&Repository::crd());
-    client.apply::<Repository>(REPO_SPEC);
+    // Executing this multiple times can cause issues with K3s, so we ensure
+    // that the code is only executed once, regardless of how many test cases
+    // try to create the repository
+    REPO_CREATED.set(true).map(|_| {
+        client.apply_crd(&Repository::crd());
+        client.apply::<Repository>(REPO_SPEC);
+    });
 }
 
 pub async fn setup_repository_async(client: &KubeClient) -> Result<()> {

--- a/src/test/repository.rs
+++ b/src/test/repository.rs
@@ -45,10 +45,10 @@ pub fn setup_repository(client: &TestKubeClient) {
     // Executing this multiple times can cause issues with K3s, so we ensure
     // that the code is only executed once, regardless of how many test cases
     // try to create the repository
-    REPO_CREATED.set(true).map(|_| {
+    if let Ok(_) = REPO_CREATED.set(true) {
         client.apply_crd(&Repository::crd());
         client.apply::<Repository>(REPO_SPEC);
-    });
+    };
 }
 
 pub async fn setup_repository_async(client: &KubeClient) -> Result<()> {


### PR DESCRIPTION

This should allow running integration tests in parallel again.

fixes #7
