### PR TITLE
Kubernetes version feature removed from the k8s-openapi dependency

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,11 +1,14 @@
 = Changelog
 
-== 0.2.1 - unreleased
+== 0.3.0 - unreleased
 
 :8: https://github.com/stackabletech/integration-test-commons/pull/8[#8]
 :9: https://github.com/stackabletech/integration-test-commons/pull/9[#9]
+:10: https://github.com/stackabletech/integration-test-commons/pull/10[#10]
 
-=== Added
+=== Removed
+* Kubernetes version feature removed from the k8s-openapi dependency. It
+  must be set by the binary crate which uses this library ({10}).
 
 === Fixed
 * Add synchronization to create the integration test repository only once per test file ({8}).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ version = "0.2.0"
 anyhow = "1.0"
 futures = "0.3"
 indoc = "1.0"
-k8s-openapi = { version = "0.12", default-features = false, features = ["v1_20"] }
+k8s-openapi = { version = "0.12", default-features = false }
 kube = "0.57"
 kube-derive = "0.57"
 kube-runtime = "0.57"
@@ -23,3 +23,6 @@ spectral = "0.6"
 stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "main" }
 tokio = { version = "1.8", features = ["rt-multi-thread"] }
 uuid = { version = "0.8", features = ["v4"] }
+
+[dev-dependencies]
+k8s-openapi = { version = "0.12", default-features = false, features = ["v1_21"] }


### PR DESCRIPTION
The compilation of the agent-integraton-tests failed with the following error message after upgrading all dependencies:

```
error: failed to run custom build command for `k8s-openapi v0.12.0`

Caused by:
  process didn't exit successfully: `/home/sigi/projects/stackable/workspace/agent-integration-tests/target/debug/build/k8s-openapi-d1b8e9eab73cae80/build-script-build` (exit code: 101)
  --- stderr
  thread 'main' panicked at '
  None of the v1_* features are enabled on the k8s-openapi crate.

  The k8s-openapi crate requires a feature to be enabled to indicate which version of Kubernetes it should support.

  If you're using k8s-openapi in a binary crate, enable the feature corresponding to the minimum version of API server that you want to support. It may be possible that your binary crate does not directly depend on k8s-openapi. In this case, add a dependency on k8s-openapi, then enable the corresponding feature.

  If you're using k8s-openapi in a library crate, add a dev-dependency on k8s-openapi and enable one of the features there. This way the feature will be enabled when buildings tests and examples of your library, but not when building the library itself. It may be possible that your library crate does not directly depend on k8s-openapi. In this case, add a dev-dependency on k8s-openapi, then enable the corresponding feature.

  Library crates *must not* enable any features in their direct dependency on k8s-openapi, only in their dev-dependency. The choice of Kubernetes version to support should be left to the final binary crate, so only the binary crate should enable a specific feature. If library crates also enable features, it can cause multiple features to be enabled simultaneously, which k8s-openapi does not support.

  If you want to restrict your library crate to support only a single specific version or range of versions of Kubernetes, please use the k8s_* version-specific macros to emit different code based on which feature gets enabled in the end.', /home/sigi/.cargo/registry/src/github.com-1ecc6299db9ec823/k8s-openapi-0.12.0/build.rs:9:42
```

Therefore I removed the Kubernetes version feature from this library and added it the dev-dependencies so that the tests can be run.