### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/test/kube.rs
+++ b/src/test/kube.rs
@@ -424,7 +424,7 @@ impl KubeClient {
             .timeout(timeout_secs);
         let mut stream = api.watch(&lp, "0").await?.boxed();
 
-        if let Some(value) = get_value(&resource) {
+        if let Some(value) = get_value(resource) {
             return Ok(value);
         }
 


### PR DESCRIPTION
## Description

Clippy warnings fixed which were introduced in Rust 1.54.

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
