### PR TITLE
Remove checking of cluster conditions when waiting for it to become ready

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target/
 Cargo.lock
 **/*.rs.bk
+*.iml

--- a/src/operator/setup.rs
+++ b/src/operator/setup.rs
@@ -121,9 +121,14 @@ where
         Ok(())
     }
 
-    /// Wait for the `expected_pod_count` count to become ready or return an error if they fail to
-    /// do so after a certain time. The amount of time, it waits is configured by the user in the
+    /// Wait for the `expected_pod_count` pods to become ready or return an error if they fail to
+    /// do so after a certain time. The amount of time it waits is configured by the user in the
     /// `cluster_ready` field of the `TestClusterTimeouts`.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `expected_pod_count` - Number of pods to wait for until they become ready.
+    /// 
     pub fn wait_ready(&self, expected_pod_count: usize) -> Result<()> {
         let now = Instant::now();
 

--- a/src/operator/setup.rs
+++ b/src/operator/setup.rs
@@ -122,14 +122,15 @@ where
     }
 
     /// Wait for the `expected_pod_count` count to become ready or return an error if they fail to
-    /// do so after a certain time.
+    /// do so after a certain time. The amount of time, it waits is configured by the user in the
+    /// `cluster_ready` field of the `TestClusterTimeouts`.
     pub fn wait_ready(&self, expected_pod_count: usize) -> Result<()> {
         let now = Instant::now();
 
         let name = self.cluster.as_ref().unwrap().name();
 
         while now.elapsed().as_secs() < self.timeouts.cluster_ready.as_secs() {
-            print!("Waiting for [{}/{}] to be ready. ", T::kind(&()), name);
+            print!("Waiting for [{}/{}] to be ready...", T::kind(&()), name);
             let created_pods = self.get_current_pods();
 
             if created_pods.len() != expected_pod_count {
@@ -144,7 +145,7 @@ where
                     self.client.verify_pod_condition(pod, "Ready");
                 }
 
-                println!("Installation finished");
+                println!("\nInstallation finished");
                 return Ok(());
             }
             thread::sleep(Duration::from_secs(2));

--- a/src/operator/setup.rs
+++ b/src/operator/setup.rs
@@ -124,11 +124,11 @@ where
     /// Wait for the `expected_pod_count` pods to become ready or return an error if they fail to
     /// do so after a certain time. The amount of time it waits is configured by the user in the
     /// `cluster_ready` field of the `TestClusterTimeouts`.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `expected_pod_count` - Number of pods to wait for until they become ready.
-    /// 
+    ///
     pub fn wait_ready(&self, expected_pod_count: usize) -> Result<()> {
         let now = Instant::now();
 


### PR DESCRIPTION
## Description

The `wait_ready()` waits for the specified number of pods to reach a ready state ignoring the conditions of the cluster they belong to.

Example output from the zookeeper-integration-tests:
```
Waiting for [ZookeeperCluster/simple-802779494] to be ready...2 of 3 pods created.                                                                                                                                 
Waiting for [ZookeeperCluster/simple-802779494] to be ready...2 of 3 pods created.
Waiting for [ZookeeperCluster/simple-802779494] to be ready...2 of 3 pods created.
Waiting for [ZookeeperCluster/simple-802779494] to be ready...2 of 3 pods created.
Waiting for [ZookeeperCluster/simple-802779494] to be ready...2 of 3 pods created.
Waiting for [ZookeeperCluster/simple-802779494] to be ready...
Installation finished      
```


## Review Checklist
- [x] Code contains useful comments

Fixes #16 